### PR TITLE
Add serial-controlled DMX channel updates

### DIFF
--- a/src/src.cpp
+++ b/src/src.cpp
@@ -35,6 +35,7 @@ void drawSelectSetup(void) {
 
 void setup(void) {
     M5.begin();
+    Serial.begin(115200);
 
     /* Configure the DMX hardware to the default DMX settings and tell the DMX
       driver which hardware pins we are using. */

--- a/src/view_sender.h
+++ b/src/view_sender.h
@@ -3,6 +3,8 @@
 #include "common.h"
 #include "logo_sender.h"
 
+#include <string>
+
 class view_sender_t : public view_t {
    public:
     void setup(void) override;
@@ -60,4 +62,9 @@ class view_sender_t : public view_t {
     void fillBar(LovyanGFX* gfx, int32_t x, int32_t y, int32_t w, int32_t h,
                  size_t ch = 0);
     void updateDisplay(bool full_redraw = false);
+    bool processSerialInput(void);
+    bool applySerialLine(const std::string& line);
+
+    std::string serial_buffer;
+    bool serial_overflow = false;
 };


### PR DESCRIPTION
## Summary
- initialize the serial port at 115200 during setup
- parse newline-terminated, comma-separated channel values from the serial input in sender mode
- update DMX channel data, UI state, and output when new serial values are received

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a73e4924832d8e729260198b5be3